### PR TITLE
Fix Python detection timeout scaling with high K values

### DIFF
--- a/custom/src/StateMachine/PythonCaptureAtSliceState.cc
+++ b/custom/src/StateMachine/PythonCaptureAtSliceState.cc
@@ -18,7 +18,7 @@
 #include <QtMath>
 
 namespace {
-static constexpr int kPythonResultTimeoutFudgeMsecs = 1000;
+static constexpr double kPythonResultTimeoutFudgeFactor = 0.5;
 }
 
 using namespace TunnelProtocol;
@@ -64,7 +64,8 @@ PythonCaptureAtSliceState::PythonCaptureAtSliceState(QState* parentState, int sl
     auto rotateCommandState         = _rotateMavlinkCommandState(this);
     auto waitForHeadingState        = new FactWaitForValueTarget(this, _vehicle->heading(), _sliceHeadingDegrees, 1.0, 10 * 1000);
     auto startDetectionState        = new SendTunnelCommandState("Python StartDetection", this, (uint8_t*)&startDetectionInfo, sizeof(startDetectionInfo));
-    const int waitForDetectionTimeoutMsecs = _customPlugin->maxWaitMSecsForKGroup() + kPythonResultTimeoutFudgeMsecs;
+    const int maxWaitMsecs = _customPlugin->maxWaitMSecsForKGroup();
+    const int waitForDetectionTimeoutMsecs = maxWaitMsecs + static_cast<int>(maxWaitMsecs * kPythonResultTimeoutFudgeFactor);
     auto waitForDetectionResultState= new PythonWaitForDetectionResultState(this, waitForDetectionTimeoutMsecs);
     auto stopDetectionState         = new SendTunnelCommandState("Python StopDetection", this, (uint8_t*)&stopDetectionInfo, sizeof(stopDetectionInfo));
     auto finalState                 = new QFinalState(this);


### PR DESCRIPTION
The Python detector result timeout used a fixed 1-second fudge factor on top of `maxWaitMSecsForKGroup()`. At high K values (e.g. k=10 with Telonics tags, ip_msecs=2000), the total timeout of 23s left insufficient headroom for the detector to complete, causing slice timeouts before results could arrive.

Replace the fixed fudge with a proportional 50% factor so the timeout scales with K. For k=10 this changes the timeout from 23s to 33s.