### PR TITLE
Use new tunnel protocol rotation detection commands for Python mode

### DIFF
--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -129,6 +129,9 @@ bool CustomPlugin::mavlinkMessage(Vehicle *vehicle, LinkInterface *link, const m
         case COMMAND_ID_HEARTBEAT:
             _handleTunnelHeartbeat(tunnel);
             return false;
+        case COMMAND_ID_BEARING_RESULT:
+            _handleBearingResult(tunnel);
+            return false;
         }
     }
 
@@ -557,10 +560,11 @@ void CustomPlugin::_sendStopDetectionDirect()
         return;
     }
 
-    qCDebug(CustomPluginLog) << "Sending direct STOP_DETECTION (Python mode cleanup)" << " - " << Q_FUNC_INFO;
+    qCDebug(CustomPluginLog) << "Sending direct STOP_ROTATION_DETECTION (Python mode cleanup)" << " - " << Q_FUNC_INFO;
 
-    StopDetectionInfo_t stopDetectionInfo;
-    stopDetectionInfo.header.command = COMMAND_ID_STOP_DETECTION;
+    StopRotationDetection_t stopRotationDetection;
+    memset(&stopRotationDetection, 0, sizeof(stopRotationDetection));
+    stopRotationDetection.header.command = COMMAND_ID_STOP_ROTATION_DETECTION;
 
     SharedLinkInterfacePtr  sharedLink  = weakLink.lock();
     MAVLinkProtocol*        mavlink     = MAVLinkProtocol::instance();
@@ -568,12 +572,12 @@ void CustomPlugin::_sendStopDetectionDirect()
     mavlink_tunnel_t        tunnel;
 
     memset(&tunnel, 0, sizeof(tunnel));
-    memcpy(tunnel.payload, &stopDetectionInfo, sizeof(stopDetectionInfo));
+    memcpy(tunnel.payload, &stopRotationDetection, sizeof(stopRotationDetection));
 
     tunnel.target_system    = vehicle->id();
     tunnel.target_component = MAV_COMP_ID_ONBOARD_COMPUTER;
     tunnel.payload_type     = MAV_TUNNEL_PAYLOAD_TYPE_UNKNOWN;
-    tunnel.payload_length   = sizeof(stopDetectionInfo);
+    tunnel.payload_length   = sizeof(stopRotationDetection);
 
     mavlink_msg_tunnel_encode_chan(
                 static_cast<uint8_t>(mavlink->getSystemId()),
@@ -637,8 +641,10 @@ void CustomPlugin::rotationIsEnding()
     if (_activeRotation) {
         _setActiveRotation(false);
 
-        // Fit bearing curve to rotation data
-        if (_rotationInfoList.count() > 0) {
+        // In C++ detector mode, fit bearing locally. In Python mode the controller
+        // computes the bearing and sends COMMAND_ID_BEARING_RESULT.
+        const bool isPythonMode = _customSettings->detectionMode()->rawValue().toUInt() == DETECTION_MODE_PYTHON;
+        if (!isPythonMode && _rotationInfoList.count() > 0) {
             auto* rotationInfo = _rotationInfoList.value<RotationInfo*>(_rotationInfoList.count() - 1);
             if (rotationInfo) {
                 rotationInfo->fitBearing();
@@ -647,6 +653,32 @@ void CustomPlugin::rotationIsEnding()
 
         csvLogManager().csvLogRotationStop();
         csvLogManager().csvStopRotationPulseLog();
+    }
+}
+
+void CustomPlugin::_handleBearingResult(const mavlink_tunnel_t& tunnel)
+{
+    if (tunnel.payload_length != sizeof(BearingResult_t)) {
+        qWarning() << "_handleBearingResult: Received incorrectly sized BearingResult payload expected:actual" << sizeof(BearingResult_t) << tunnel.payload_length;
+        return;
+    }
+
+    BearingResult_t bearingResult;
+    memcpy(&bearingResult, tunnel.payload, sizeof(bearingResult));
+
+    qCDebug(CustomPluginLog) << "BearingResult received - tag_id:bearing:r2:nValid:bestSNR"
+                             << bearingResult.tag_id
+                             << bearingResult.bearing_deg
+                             << bearingResult.r_squared
+                             << bearingResult.n_valid_slices
+                             << bearingResult.best_snr;
+
+    if (_rotationInfoList.count() > 0) {
+        auto* rotationInfo = _rotationInfoList.value<RotationInfo*>(_rotationInfoList.count() - 1);
+        if (rotationInfo) {
+            rotationInfo->setBearingResult(bearingResult.bearing_deg, bearingResult.r_squared,
+                                           bearingResult.n_valid_slices, bearingResult.best_snr);
+        }
     }
 }
 

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -110,6 +110,7 @@ private slots:
 private:
     void    _handleTunnelPulse          (Vehicle* vehicle, const mavlink_tunnel_t& tunnel);
     void    _handleTunnelHeartbeat      (const mavlink_tunnel_t& tunnel);
+    void    _handleBearingResult        (const mavlink_tunnel_t& tunnel);
     void    _say                        (QString text);
     int     _rawPulseToPct              (double rawPulse);
     bool    _useSNRForPulseStrength     (void) { return _customSettings->useSNRForPulseStrength()->rawValue().toBool(); }

--- a/custom/src/RotationInfo.cc
+++ b/custom/src/RotationInfo.cc
@@ -483,3 +483,20 @@ void RotationInfo::fitBearing(void)
 
     emit bearingChanged();
 }
+
+void RotationInfo::setBearingResult(float bearingDeg, float rSquared, uint32_t nValidSlices, float bestSNR)
+{
+    _bearingDeg         = static_cast<double>(bearingDeg);
+    _bearingRSquared    = static_cast<double>(rSquared);
+    _bearingUncertainty = qQNaN();
+    _bearingAmbiguous   = false;
+    _bearingValid       = nValidSlices >= 3;
+
+    qCDebug(CustomPluginLog) << "BearingResult applied: bearing" << _bearingDeg
+                             << "R²" << _bearingRSquared
+                             << "nValidSlices" << nValidSlices
+                             << "bestSNR" << bestSNR
+                             << "valid" << _bearingValid;
+
+    emit bearingChanged();
+}

--- a/custom/src/RotationInfo.h
+++ b/custom/src/RotationInfo.h
@@ -34,6 +34,7 @@ public:
 
     void pulseInfoReceived(const TunnelProtocol::PulseInfo_t& pulseInfo);
     void fitBearing(void);
+    void setBearingResult(float bearingDeg, float rSquared, uint32_t nValidSlices, float bestSNR);
 
 signals:
     void pulseRateCountsChanged(void);

--- a/custom/src/StateMachine/PythonCaptureAtSliceState.cc
+++ b/custom/src/StateMachine/PythonCaptureAtSliceState.cc
@@ -7,7 +7,6 @@
 #include "CustomPlugin.h"
 #include "CustomSettings.h"
 #include "CustomLoggingCategory.h"
-#include "TagDatabase.h"
 #include "TunnelProtocol.h"
 
 #include "MultiVehicleManager.h"
@@ -41,42 +40,37 @@ PythonCaptureAtSliceState::PythonCaptureAtSliceState(QState* parentState, int sl
 
     double antennaOffset = _customSettings->antennaOffset()->rawValue().toDouble();
     _sliceHeadingDegrees += -antennaOffset;
+    _sliceHeadingDegrees = fmod(_sliceHeadingDegrees, 360.0);
+    if (_sliceHeadingDegrees < 0.0) {
+        _sliceHeadingDegrees += 360.0;
+    }
 
     connect(this, &QState::entered, this, [this] () {
         qCDebug(CustomStateMachineLog) << QStringLiteral("Python: rotating to heading %1").arg(_sliceHeadingDegrees) << " - " << Q_FUNC_INFO;
     });
 
-    // Build StartDetectionInfo for this slice
-    StartDetectionInfo_t startDetectionInfo;
-    memset(&startDetectionInfo, 0, sizeof(startDetectionInfo));
-    startDetectionInfo.header.command               = COMMAND_ID_START_DETECTION;
-    startDetectionInfo.radio_center_frequency_hz    = TagDatabase::instance()->channelizerTuner();
-    startDetectionInfo.gain                         = _customSettings->gain()->rawValue().toUInt();
-    startDetectionInfo.detection_mode               = DETECTION_MODE_PYTHON;
-    startDetectionInfo.detection_margin             = _customSettings->detectionMargin()->rawValue().toDouble();
-    startDetectionInfo.confidence_ratio             = _customSettings->confidenceRatio()->rawValue().toDouble();
-
-    StopDetectionInfo_t stopDetectionInfo;
-    stopDetectionInfo.header.command = COMMAND_ID_STOP_DETECTION;
+    // Build StartDetectionAtHeading for this slice
+    StartDetectionAtHeading_t startAtHeading;
+    memset(&startAtHeading, 0, sizeof(startAtHeading));
+    startAtHeading.header.command = COMMAND_ID_START_DETECTION_AT_HEADING;
+    startAtHeading.heading_deg    = static_cast<float>(_sliceHeadingDegrees);
 
     // States
     auto announceRotateState        = new SayState("Announce Rotate", this, QStringLiteral("Searching at %1 degrees").arg(_sliceHeadingDegrees));
     auto rotateCommandState         = _rotateMavlinkCommandState(this);
     auto waitForHeadingState        = new FactWaitForValueTarget(this, _vehicle->heading(), _sliceHeadingDegrees, 1.0, 10 * 1000);
-    auto startDetectionState        = new SendTunnelCommandState("Python StartDetection", this, (uint8_t*)&startDetectionInfo, sizeof(startDetectionInfo));
+    auto startAtHeadingState        = new SendTunnelCommandState("Python StartDetectionAtHeading", this, (uint8_t*)&startAtHeading, sizeof(startAtHeading));
     const int maxWaitMsecs = _customPlugin->maxWaitMSecsForKGroup();
     const int waitForDetectionTimeoutMsecs = maxWaitMsecs + static_cast<int>(maxWaitMsecs * kPythonResultTimeoutFudgeFactor);
     auto waitForDetectionResultState= new PythonWaitForDetectionResultState(this, waitForDetectionTimeoutMsecs);
-    auto stopDetectionState         = new SendTunnelCommandState("Python StopDetection", this, (uint8_t*)&stopDetectionInfo, sizeof(stopDetectionInfo));
     auto finalState                 = new QFinalState(this);
 
     // Transitions
     announceRotateState->addTransition      (announceRotateState,           &SayState::functionCompleted,               rotateCommandState);
     rotateCommandState->addTransition       (rotateCommandState,            &SendMavlinkCommandState::success,          waitForHeadingState);
-    waitForHeadingState->addTransition      (waitForHeadingState,           &FactWaitForValueTarget::success,           startDetectionState);
-    startDetectionState->addTransition      (startDetectionState,           &SendTunnelCommandState::commandSucceeded,  waitForDetectionResultState);
-    waitForDetectionResultState->addTransition(waitForDetectionResultState, &QState::finished,                          stopDetectionState);
-    stopDetectionState->addTransition       (stopDetectionState,            &SendTunnelCommandState::commandSucceeded,  finalState);
+    waitForHeadingState->addTransition      (waitForHeadingState,           &FactWaitForValueTarget::success,           startAtHeadingState);
+    startAtHeadingState->addTransition      (startAtHeadingState,           &SendTunnelCommandState::commandSucceeded,  waitForDetectionResultState);
+    waitForDetectionResultState->addTransition(waitForDetectionResultState, &QState::finished,                          finalState);
 
     setInitialState(announceRotateState);
 }

--- a/custom/src/StateMachine/PythonRotateAndCaptureState.cc
+++ b/custom/src/StateMachine/PythonRotateAndCaptureState.cc
@@ -1,12 +1,17 @@
 #include "PythonRotateAndCaptureState.h"
 #include "PythonCaptureAtSliceState.h"
+#include "SendTunnelCommandState.h"
 #include "FunctionState.h"
 #include "SayState.h"
 #include "CustomPlugin.h"
 #include "CustomSettings.h"
 #include "CustomLoggingCategory.h"
+#include "TagDatabase.h"
+#include "TunnelProtocol.h"
 
 #include <QFinalState>
+
+using namespace TunnelProtocol;
 
 PythonRotateAndCaptureState::PythonRotateAndCaptureState(QState* parentState)
     : CustomState       ("PythonRotateAndCaptureState", parentState)
@@ -15,10 +20,26 @@ PythonRotateAndCaptureState::PythonRotateAndCaptureState(QState* parentState)
 {
     const int rotationDivisions     = _customSettings->divisions()->rawValue().toInt();
 
-    auto rotationBeginState         = new FunctionState("Rotation Begin", this, std::bind(&PythonRotateAndCaptureState::_rotationBegin, this));
-    auto rotationEndState           = new FunctionState("Rotation End",   this, std::bind(&PythonRotateAndCaptureState::_rotationEnd, this));
-    auto announceRotateCompleteState= new SayState("Announce Rotate Complete", this, "Rotation detection complete");
-    auto finalState                 = new QFinalState(this);
+    // Build StartRotationDetection command
+    StartRotationDetection_t startRotationDetection;
+    memset(&startRotationDetection, 0, sizeof(startRotationDetection));
+    startRotationDetection.header.command            = COMMAND_ID_START_ROTATION_DETECTION;
+    startRotationDetection.radio_center_frequency_hz = TagDatabase::instance()->channelizerTuner();
+    startRotationDetection.n_slices                  = rotationDivisions;
+    startRotationDetection.detection_margin          = _customSettings->detectionMargin()->rawValue().toDouble();
+    startRotationDetection.confidence_ratio          = _customSettings->confidenceRatio()->rawValue().toDouble();
+
+    // Build StopRotationDetection command
+    StopRotationDetection_t stopRotationDetection;
+    memset(&stopRotationDetection, 0, sizeof(stopRotationDetection));
+    stopRotationDetection.header.command = COMMAND_ID_STOP_ROTATION_DETECTION;
+
+    auto rotationBeginState             = new FunctionState("Rotation Begin", this, std::bind(&PythonRotateAndCaptureState::_rotationBegin, this));
+    auto startRotationDetectionState    = new SendTunnelCommandState("StartRotationDetection", this, reinterpret_cast<uint8_t*>(&startRotationDetection), sizeof(startRotationDetection));
+    auto stopRotationDetectionState     = new SendTunnelCommandState("StopRotationDetection", this, reinterpret_cast<uint8_t*>(&stopRotationDetection), sizeof(stopRotationDetection));
+    auto rotationEndState               = new FunctionState("Rotation End",   this, std::bind(&PythonRotateAndCaptureState::_rotationEnd, this));
+    auto announceRotateCompleteState    = new SayState("Announce Rotate Complete", this, "Rotation detection complete");
+    auto finalState                     = new QFinalState(this);
 
     // Build the per-slice states
     QList<PythonCaptureAtSliceState*> sliceStates;
@@ -26,14 +47,16 @@ PythonRotateAndCaptureState::PythonRotateAndCaptureState(QState* parentState)
         sliceStates.append(new PythonCaptureAtSliceState(this, i));
     }
 
-    // Transitions: rotationBegin → slice[0] → slice[1] → ... → slice[N-1] → rotationEnd
-    rotationBeginState->addTransition(rotationBeginState, &FunctionState::functionCompleted, sliceStates.first());
+    // Transitions: rotationBegin → startRotationDetection → slice[0] → ... → slice[N-1] → stopRotationDetection → rotationEnd
+    rotationBeginState->addTransition(rotationBeginState, &FunctionState::functionCompleted, startRotationDetectionState);
+    startRotationDetectionState->addTransition(startRotationDetectionState, &SendTunnelCommandState::commandSucceeded, sliceStates.first());
 
     for (int i = 0; i < sliceStates.count() - 1; i++) {
         sliceStates[i]->addTransition(sliceStates[i], &QState::finished, sliceStates[i + 1]);
     }
-    sliceStates.last()->addTransition(sliceStates.last(), &QState::finished, rotationEndState);
+    sliceStates.last()->addTransition(sliceStates.last(), &QState::finished, stopRotationDetectionState);
 
+    stopRotationDetectionState->addTransition(stopRotationDetectionState, &SendTunnelCommandState::commandSucceeded, rotationEndState);
     rotationEndState->addTransition(rotationEndState, &FunctionState::functionCompleted, announceRotateCompleteState);
     announceRotateCompleteState->addTransition(announceRotateCompleteState, &SayState::functionCompleted, finalState);
 

--- a/custom/src/StateMachine/SendTunnelCommandState.cc
+++ b/custom/src/StateMachine/SendTunnelCommandState.cc
@@ -71,6 +71,14 @@ QString SendTunnelCommandState::commandIdToText(uint32_t vhfCommandId)
         return QStringLiteral("Clean Logs");
     case COMMAND_ID_AIRSPY_STATUS:
         return QStringLiteral("Airspy Status");
+    case COMMAND_ID_START_ROTATION_DETECTION:
+        return QStringLiteral("Start Rotation Detection");
+    case COMMAND_ID_START_DETECTION_AT_HEADING:
+        return QStringLiteral("Start Detection At Heading");
+    case COMMAND_ID_STOP_ROTATION_DETECTION:
+        return QStringLiteral("Stop Rotation Detection");
+    case COMMAND_ID_BEARING_RESULT:
+        return QStringLiteral("Bearing Result");
     default:
         return QStringLiteral("Unknown command: %1").arg(vhfCommandId);
     }


### PR DESCRIPTION
## Changes

- **PythonRotateAndCaptureState**: Send `START_ROTATION_DETECTION` at rotation begin and `STOP_ROTATION_DETECTION` at rotation end instead of per-slice `START/STOP_DETECTION`
- **PythonCaptureAtSliceState**: Replace per-slice `START_DETECTION`/`STOP_DETECTION` with single `START_DETECTION_AT_HEADING` (controller auto-stops on pulse/no-pulse)
- **CustomPlugin**: Handle incoming `COMMAND_ID_BEARING_RESULT` from controller and route to `RotationInfo::setBearingResult()`. Only call `fitBearing()` locally for C++ detector mode
- **CustomPlugin**: Cancel handler sends `STOP_ROTATION_DETECTION` instead of `STOP_DETECTION` in Python mode
- **RotationInfo**: Add `setBearingResult()` for controller-computed bearing results
- **SendTunnelCommandState**: Add new command IDs to `commandIdToText()`
- Update tunnel-protocol submodule to head