### PR TITLE
Add workflow_dispatch trigger to CI workflows

### DIFF
--- a/.github/workflows/herelink-linux.yml
+++ b/.github/workflows/herelink-linux.yml
@@ -1,6 +1,7 @@
 name: Herelink-Linux
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,7 @@
 name: macOS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Add `workflow_dispatch` trigger to the macOS and Herelink-Linux CI workflows so builds can be kicked off manually from the GitHub Actions UI.

The `docs` and `cache-cleanup` workflows already had this trigger.
